### PR TITLE
feat: add `publish_image` workflow

### DIFF
--- a/.github/actions/run_renovate_with_bazel/Dockerfile
+++ b/.github/actions/run_renovate_with_bazel/Dockerfile
@@ -8,9 +8,12 @@ RUN npm install -g @bazel/bazelisk
 # https://apt.llvm.org/
 # bash -c "$(curl -fsSL https://apt.llvm.org/llvm.sh)"
 # install-tool llvm-toolchain 16.0.0
-RUN install-tool clang-16 16.0.0
-RUN install-tool lldb-16 16.0.0
-RUN install-tool lld-16 16.0.0
+# install-tool clang-16 16.0.0
+# install-tool lldb-16 16.0.0
+# install-tool lld-16 16.0.0
+RUN install-tool clang 16.0.0
+RUN install-tool lldb 16.0.0
+RUN install-tool lld 16.0.0
 
 COPY fake_entrypoint.sh /fake_entrypoint.sh
 

--- a/.github/actions/run_renovate_with_bazel/Dockerfile
+++ b/.github/actions/run_renovate_with_bazel/Dockerfile
@@ -9,17 +9,6 @@ USER 1000
 # Install Bazelisk
 RUN npm install -g @bazel/bazelisk
 
-# Install latest stable clang
-# https://apt.llvm.org/
-# bash -c "$(curl -fsSL https://apt.llvm.org/llvm.sh)"
-# install-tool llvm-toolchain 16.0.0
-# install-tool clang-16 16.0.0
-# install-tool lldb-16 16.0.0
-# install-tool lld-16 16.0.0
-# RUN install-tool clang 16.0.0
-# RUN install-tool lldb 16.0.0
-# RUN install-tool lld 16.0.0
-
 COPY fake_entrypoint.sh /fake_entrypoint.sh
 
 ENTRYPOINT ["/fake_entrypoint.sh"]

--- a/.github/actions/run_renovate_with_bazel/Dockerfile
+++ b/.github/actions/run_renovate_with_bazel/Dockerfile
@@ -1,6 +1,11 @@
 # Based on Renovate image
 FROM ghcr.io/renovatebot/renovate:36.24
 
+# Install clang
+USER 0
+RUN install-apt clang
+USER 1000
+
 # Install Bazelisk
 RUN npm install -g @bazel/bazelisk
 
@@ -11,9 +16,9 @@ RUN npm install -g @bazel/bazelisk
 # install-tool clang-16 16.0.0
 # install-tool lldb-16 16.0.0
 # install-tool lld-16 16.0.0
-RUN install-tool clang 16.0.0
-RUN install-tool lldb 16.0.0
-RUN install-tool lld 16.0.0
+# RUN install-tool clang 16.0.0
+# RUN install-tool lldb 16.0.0
+# RUN install-tool lld 16.0.0
 
 COPY fake_entrypoint.sh /fake_entrypoint.sh
 

--- a/.github/actions/run_renovate_with_bazel/Dockerfile
+++ b/.github/actions/run_renovate_with_bazel/Dockerfile
@@ -4,11 +4,8 @@ FROM ghcr.io/renovatebot/renovate:36.24
 # Install Bazelisk
 RUN npm install -g @bazel/bazelisk
 
-RUN install-tool wget 1.21.2
-
 # Install latest stable clang
 # https://apt.llvm.org/
-# RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 RUN bash -c "$(curl -fsSL https://apt.llvm.org/llvm.sh)"
 
 COPY fake_entrypoint.sh /fake_entrypoint.sh

--- a/.github/actions/run_renovate_with_bazel/Dockerfile
+++ b/.github/actions/run_renovate_with_bazel/Dockerfile
@@ -6,7 +6,8 @@ RUN npm install -g @bazel/bazelisk
 
 # Install latest stable clang
 # https://apt.llvm.org/
-RUN bash -c "$(curl -fsSL https://apt.llvm.org/llvm.sh)"
+# bash -c "$(curl -fsSL https://apt.llvm.org/llvm.sh)"
+RUN install-tool llvm-toolchain 16.0.0
 
 COPY fake_entrypoint.sh /fake_entrypoint.sh
 

--- a/.github/actions/run_renovate_with_bazel/Dockerfile
+++ b/.github/actions/run_renovate_with_bazel/Dockerfile
@@ -8,7 +8,8 @@ RUN install-tool wget 1.21.2
 
 # Install latest stable clang
 # https://apt.llvm.org/
-RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+# RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+RUN bash -c "$(curl -fsSL https://apt.llvm.org/llvm.sh)"
 
 COPY fake_entrypoint.sh /fake_entrypoint.sh
 

--- a/.github/actions/run_renovate_with_bazel/Dockerfile
+++ b/.github/actions/run_renovate_with_bazel/Dockerfile
@@ -9,6 +9,6 @@ USER 1000
 # Install Bazelisk
 RUN npm install -g @bazel/bazelisk
 
-COPY fake_entrypoint.sh /fake_entrypoint.sh
+# COPY fake_entrypoint.sh /fake_entrypoint.sh
 
-ENTRYPOINT ["/fake_entrypoint.sh"]
+# ENTRYPOINT ["/fake_entrypoint.sh"]

--- a/.github/actions/run_renovate_with_bazel/Dockerfile
+++ b/.github/actions/run_renovate_with_bazel/Dockerfile
@@ -7,7 +7,10 @@ RUN npm install -g @bazel/bazelisk
 # Install latest stable clang
 # https://apt.llvm.org/
 # bash -c "$(curl -fsSL https://apt.llvm.org/llvm.sh)"
-RUN install-tool llvm-toolchain 16.0.0
+# install-tool llvm-toolchain 16.0.0
+RUN install-tool clang-16 16.0.0
+RUN install-tool lldb-16 16.0.0
+RUN install-tool lld-16 16.0.0
 
 COPY fake_entrypoint.sh /fake_entrypoint.sh
 

--- a/.github/actions/run_renovate_with_bazel/Dockerfile
+++ b/.github/actions/run_renovate_with_bazel/Dockerfile
@@ -4,6 +4,10 @@ FROM ghcr.io/renovatebot/renovate:36.24
 # Install Bazelisk
 RUN npm install -g @bazel/bazelisk
 
+# Install latest stable clang
+# https://apt.llvm.org/
+RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+
 COPY fake_entrypoint.sh /fake_entrypoint.sh
 
 ENTRYPOINT ["/fake_entrypoint.sh"]

--- a/.github/actions/run_renovate_with_bazel/Dockerfile
+++ b/.github/actions/run_renovate_with_bazel/Dockerfile
@@ -4,6 +4,8 @@ FROM ghcr.io/renovatebot/renovate:36.24
 # Install Bazelisk
 RUN npm install -g @bazel/bazelisk
 
+RUN install-tool wget 1.21.2
+
 # Install latest stable clang
 # https://apt.llvm.org/
 RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"

--- a/.github/actions/run_renovate_with_bazel/fake_entrypoint.sh
+++ b/.github/actions/run_renovate_with_bazel/fake_entrypoint.sh
@@ -3,7 +3,7 @@
 # DEBUG BEGIN
 set -x
 
-which bazelisk
-which clang
-which renovate
+which bazelisk || echo "bazelisk not found"
+which clang || echo "clang not found"
+which renovate || echo "renovate not found"
 # DEBUG END

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -1,0 +1,47 @@
+name: Publish a Docker image for Renovate with extra tools (e.g. Bazel)
+
+# Runs when a new release is creatd
+on:
+  release:
+    types: [published]
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: ./renovate_image
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/renovate_image/Dockerfile
+++ b/renovate_image/Dockerfile
@@ -1,0 +1,12 @@
+# Based on Renovate image
+FROM ghcr.io/renovatebot/renovate:36.24
+
+# Install clang
+USER 0
+RUN install-apt clang
+USER 1000
+
+# Install Bazelisk
+RUN npm install -g @bazel/bazelisk
+
+# Use the entrypoint from the Renovate image


### PR DESCRIPTION
The action creates and publishes a Docker image based upon the Renovate image. It also includes Bazelisk and clang.
