### PR TITLE
chore: rename deprecated allowedPostUpgradeCommands to allowedCommands

### DIFF
--- a/.github/renovate-global.json
+++ b/.github/renovate-global.json
@@ -7,7 +7,7 @@
   "platform": "github",
   "username": "cgrindel-self-hosted-renovate[bot]",
   "gitAuthor": "Self-hosted Renovate Bot <361546+cgrindel-self-hosted-renovate[bot]@users.noreply.github.enterprise.com>",
-  "allowedPostUpgradeCommands": [
+  "allowedCommands": [
     "^npm",
     "^./do_renovate_post_upgrade",
     "^bazelisk run //:tidy"


### PR DESCRIPTION
## Summary

- Rename `allowedPostUpgradeCommands` to `allowedCommands` in the global self-hosted Renovate config
- The old name was deprecated in Renovate v39.131 and auto-migrates, but using the current name avoids future breakage

## Test plan

- [ ] Merge and verify next Renovate run processes repos without config warnings
- [ ] Verify post-upgrade tasks still execute on rules_swift_package_manager PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)